### PR TITLE
Replace ellipsis with ellipsis character to fix lint error

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -125,7 +125,7 @@
 
     <string name="auth_connecting" formatted="false">Подключение к сети %s</string>
     <string name="auth_version" formatted="false">Версия алгоритма: %d</string>
-    <string name="auth_waiting">Ожидание...</string>
+    <string name="auth_waiting">Ожидание…</string>
     <string name="auth_checking_connection">Проверка доступа в интернет</string>
     <string name="auth_already_connected">Уже подключено</string>
     <string name="auth_restarting_wifi">Перезапуск Wi-Fi…</string>


### PR DESCRIPTION
Исправил простейшую из ошибок, найденных Android Lint